### PR TITLE
Add LineChart component

### DIFF
--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -49,11 +49,8 @@ const LineChart = ({
   // Get max y if not provided
   yMax = useMemo(
     () =>
-      yMax
-        ? yMax
-        : Math.max(
-            ...data.map(lineData => Math.max(...lineData.map(d => d.y)))
-          ),
+      yMax ||
+      Math.max(...data.map(lineData => Math.max(...lineData.map(d => d.y)))),
     [data, yMax]
   );
 

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -1,10 +1,7 @@
-'use client';
-
 import { Axis } from '@visx/axis';
 import { scaleLinear } from '@visx/scale';
 import { LinearGradient } from '@visx/gradient';
 import { LinePath } from '@visx/shape';
-import { theme as antdTheme } from 'antd';
 import { curveNatural } from '@visx/curve';
 import { AreaClosed } from '@visx/shape';
 import theme from '@/theme/theme';
@@ -34,8 +31,6 @@ const LineChart = ({
   padding = 50,
   yUnit
 }: LineChartProps) => {
-  const { token } = antdTheme.useToken();
-
   const scaleX = scaleLinear({
     domain: [xMin, data[0].length],
     range: [padding, width - padding]
@@ -53,18 +48,18 @@ const LineChart = ({
         y={0}
         width={width}
         height={height}
-        fill={token.colorWhite}
+        fill={theme.color.white}
         rx={14}
       />
       <Axis
         scale={scaleX}
         top={height - padding}
         orientation="bottom"
-        stroke={token.colorTextDescription}
+        stroke={theme.color.textDescription}
         hideTicks
         tickLabelProps={() => ({
-          fill: token.colorTextDescription,
-          fontSize: token.fontSize,
+          fill: theme.color.textDescription,
+          fontSize: theme.fontSize,
           textAnchor: 'middle',
           verticalAnchor: 'middle'
         })}
@@ -73,11 +68,11 @@ const LineChart = ({
         scale={scaleY}
         left={padding}
         orientation="left"
-        stroke={token.colorTextDescription}
+        stroke={theme.color.textDescription}
         hideTicks
         tickLabelProps={() => ({
-          fill: token.colorTextDescription,
-          fontSize: token.fontSize,
+          fill: theme.color.textDescription,
+          fontSize: theme.fontSize,
           textAnchor: 'end',
           verticalAnchor: 'middle'
         })}
@@ -90,7 +85,7 @@ const LineChart = ({
             key={`background-gradient-${i}`}
             id={`background-gradient-${i}`}
             from={theme.chartColors[i]}
-            to={token.colorWhite}
+            to={theme.color.white}
             fromOpacity={0.2}
             toOpacity={0.2}
           />

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -16,29 +16,54 @@ interface LineChartProps {
   width: number;
   height: number;
   data: ChartData[][];
-  xMin: number;
   yMax: number;
   padding?: number;
   hideAxis?: boolean;
   yUnit?: string;
 }
 
+const chartColors = [theme.color.blue, theme.color.pink, theme.color.pink];
+
 const LineChart = ({
   width,
   height,
   data,
-  xMin,
   yMax,
-  padding = 50,
+  padding = 50, // Doesn't have to be consistent with our theme
   yUnit
 }: LineChartProps) => {
+  // Get min x
+  const xMin = useMemo(
+    () =>
+      Math.min(...data.map(lineData => Math.min(...lineData.map(d => d.x)))),
+    [data]
+  );
+
+  // Get max x
+  const xMax = useMemo(
+    () =>
+      Math.max(...data.map(lineData => Math.max(...lineData.map(d => d.x)))),
+    [data]
+  );
+
+  // Get max y if not provided
+  yMax = useMemo(
+    () =>
+      yMax
+        ? yMax
+        : Math.max(
+            ...data.map(lineData => Math.max(...lineData.map(d => d.y)))
+          ),
+    [data, yMax]
+  );
+
   const scaleX = useMemo(
     () =>
       scaleLinear({
-        domain: [xMin, data[0].length],
+        domain: [xMin, xMax],
         range: [padding, width - padding]
       }),
-    [xMin, data, padding, width]
+    [xMin, xMax, padding, width]
   );
 
   const scaleY = useMemo(
@@ -58,29 +83,30 @@ const LineChart = ({
         width={width}
         height={height}
         fill={theme.color.white}
-        rx={14}
       />
       <Axis
         scale={scaleX}
         top={height - padding}
         orientation="bottom"
-        stroke={theme.color.textDescription}
+        stroke={theme.color.ligthGray}
         hideTicks
         tickLabelProps={() => ({
-          fill: theme.color.textDescription,
+          fill: theme.color.ligthGray,
           fontSize: theme.fontSize,
           textAnchor: 'middle',
           verticalAnchor: 'middle'
         })}
+        tickValues={data[0].map(d => d.x)} // Only show ticks for x values
+        tickFormat={value => `${value}`}
       />
       <Axis
         scale={scaleY}
         left={padding}
         orientation="left"
-        stroke={theme.color.textDescription}
+        stroke={theme.color.ligthGray}
         hideTicks
         tickLabelProps={() => ({
-          fill: theme.color.textDescription,
+          fill: theme.color.ligthGray,
           fontSize: theme.fontSize,
           textAnchor: 'end',
           verticalAnchor: 'middle'
@@ -93,7 +119,7 @@ const LineChart = ({
           <LinearGradient
             key={`background-gradient-${i}`}
             id={`background-gradient-${i}`}
-            from={theme.chartColors[i]}
+            from={chartColors[i]}
             to={theme.color.white}
             fromOpacity={0.2}
             toOpacity={0.2}
@@ -111,8 +137,8 @@ const LineChart = ({
             data={lineData}
             x={d => scaleX(d.x)}
             y={d => scaleY(d.y)}
-            stroke={theme.chartColors[i]}
-            strokeWidth={3}
+            stroke={chartColors[i]}
+            strokeWidth={theme.strokeWidth.m}
             curve={curveNatural}
           />
         </>

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -5,6 +5,7 @@ import { LinePath } from '@visx/shape';
 import { curveNatural } from '@visx/curve';
 import { AreaClosed } from '@visx/shape';
 import theme from '@/theme/theme';
+import { useMemo } from 'react';
 
 interface ChartData {
   x: number;
@@ -31,15 +32,23 @@ const LineChart = ({
   padding = 50,
   yUnit
 }: LineChartProps) => {
-  const scaleX = scaleLinear({
-    domain: [xMin, data[0].length],
-    range: [padding, width - padding]
-  });
+  const scaleX = useMemo(
+    () =>
+      scaleLinear({
+        domain: [xMin, data[0].length],
+        range: [padding, width - padding]
+      }),
+    [xMin, data, padding, width]
+  );
 
-  const scaleY = scaleLinear({
-    domain: [0, yMax],
-    range: [height - padding, padding]
-  });
+  const scaleY = useMemo(
+    () =>
+      scaleLinear({
+        domain: [0, yMax],
+        range: [height - padding, padding]
+      }),
+    [yMax, height, padding]
+  );
 
   return (
     <svg width={width} height={height}>

--- a/src/components/charts/LineChart.tsx
+++ b/src/components/charts/LineChart.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { Axis } from '@visx/axis';
+import { scaleLinear } from '@visx/scale';
+import { LinearGradient } from '@visx/gradient';
+import { LinePath } from '@visx/shape';
+import { theme as antdTheme } from 'antd';
+import { curveNatural } from '@visx/curve';
+import { AreaClosed } from '@visx/shape';
+import theme from '@/theme/theme';
+
+interface ChartData {
+  x: number;
+  y: number;
+}
+
+interface LineChartProps {
+  width: number;
+  height: number;
+  data: ChartData[][];
+  xMin: number;
+  yMax: number;
+  padding?: number;
+  hideAxis?: boolean;
+  yUnit?: string;
+}
+
+const LineChart = ({
+  width,
+  height,
+  data,
+  xMin,
+  yMax,
+  padding = 50,
+  yUnit
+}: LineChartProps) => {
+  const { token } = antdTheme.useToken();
+
+  const scaleX = scaleLinear({
+    domain: [xMin, data[0].length],
+    range: [padding, width - padding]
+  });
+
+  const scaleY = scaleLinear({
+    domain: [0, yMax],
+    range: [height - padding, padding]
+  });
+
+  return (
+    <svg width={width} height={height}>
+      <rect
+        x={0}
+        y={0}
+        width={width}
+        height={height}
+        fill={token.colorWhite}
+        rx={14}
+      />
+      <Axis
+        scale={scaleX}
+        top={height - padding}
+        orientation="bottom"
+        stroke={token.colorTextDescription}
+        hideTicks
+        tickLabelProps={() => ({
+          fill: token.colorTextDescription,
+          fontSize: token.fontSize,
+          textAnchor: 'middle',
+          verticalAnchor: 'middle'
+        })}
+      />
+      <Axis
+        scale={scaleY}
+        left={padding}
+        orientation="left"
+        stroke={token.colorTextDescription}
+        hideTicks
+        tickLabelProps={() => ({
+          fill: token.colorTextDescription,
+          fontSize: token.fontSize,
+          textAnchor: 'end',
+          verticalAnchor: 'middle'
+        })}
+        tickFormat={yUnit ? value => `${value}${yUnit}` : undefined}
+        hideZero
+      />
+      {data.map((lineData, i) => (
+        <>
+          <LinearGradient
+            key={`background-gradient-${i}`}
+            id={`background-gradient-${i}`}
+            from={theme.chartColors[i]}
+            to={token.colorWhite}
+            fromOpacity={0.2}
+            toOpacity={0.2}
+          />
+          <AreaClosed
+            key={`area-${i}`}
+            data={lineData}
+            x={d => scaleX(d.x)}
+            y={d => scaleY(d.y)}
+            yScale={scaleY}
+            fill={`url('#background-gradient-${i}')`}
+            curve={curveNatural}
+          />
+          <LinePath
+            data={lineData}
+            x={d => scaleX(d.x)}
+            y={d => scaleY(d.y)}
+            stroke={theme.chartColors[i]}
+            strokeWidth={3}
+            curve={curveNatural}
+          />
+        </>
+      ))}
+    </svg>
+  );
+};
+
+export default LineChart;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -23,12 +23,13 @@ const theme = {
     m: '12px',
     l: '24px'
   },
+  chartColors: ['#277aff', '#ca5dd9', '#f6b033'],
   /**
    *  AntD:
    **/
   token: {
     colorSuccess: '#0aad6a',
-    colorInfo: '#3f2547',
+    colorInfo: '#ca5dd9',
     colorWarning: '#f6b033',
     colorError: '#f63535',
     colorTextBase: '#24132b',

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -8,7 +8,10 @@ const lexend = Lexend({
 const theme = {
   color: {
     primary: '#3f2547',
-    gray: '#7a7a7a'
+    gray: '#7a7a7a',
+    white: '#fff',
+    textBase: 'rgba(36, 19, 43, 0.88)',
+    textDescription: 'rgba(36, 19, 43, 0.45)'
   },
   padding: {
     xs: '4px',
@@ -24,6 +27,7 @@ const theme = {
     l: '24px'
   },
   chartColors: ['#277aff', '#ca5dd9', '#f6b033'],
+  fontSize: 14,
   /**
    *  AntD:
    **/

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -10,8 +10,10 @@ const theme = {
     primary: '#3f2547',
     gray: '#7a7a7a',
     white: '#fff',
-    textBase: 'rgba(36, 19, 43, 0.88)',
-    textDescription: 'rgba(36, 19, 43, 0.45)'
+    blue: '#277aff',
+    pink: '#ca5dd9',
+    orange: '#f6b033',
+    ligthGray: 'rgba(36, 19, 43, 0.45)'
   },
   padding: {
     xs: '4px',
@@ -26,8 +28,13 @@ const theme = {
     m: '12px',
     l: '24px'
   },
-  chartColors: ['#277aff', '#ca5dd9', '#f6b033'],
   fontSize: 14,
+  strokeWidth: {
+    xs: 0.5,
+    s: 1,
+    m: 3,
+    l: 6
+  },
   /**
    *  AntD:
    **/


### PR DESCRIPTION
This PR adds a basic implementation of a LineChart Component that supports multiple lines and datapoints. In order to use Antd's theme values `'use client'` had to be added at the start of the page (this will be removed once we find a solution).

<img width="983" alt="image" src="https://github.com/tum-v2/parloa-ui/assets/46896242/e0efb08c-85df-4c9f-bc14-dab6c64a4458">
