### PR TITLE
Fix/input field

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,13 +3,21 @@
 @tailwind utilities;
 
 body {
-    color: var(--color-text);
+  color: var(--color-text);
 }
 
-button, input, textarea, select {
-    color: inherit;
+button,
+input,
+textarea,
+select {
+  color: inherit;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-lexend);
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-lexend);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,5 @@
-// eslint-disable-next-line require-jsdoc
-
 import NavBar from '@/components/nav-bar';
-
+// eslint-disable-next-line require-jsdoc
 export default function Page() {
   return (
     <div>

--- a/src/app/simulations/page.tsx
+++ b/src/app/simulations/page.tsx
@@ -1,4 +1,5 @@
-// import InputField from '@/components/generic/InputField';
+// 'use client';
+// import { InputField } from '@/components/generic/InputField';
 // import { BsFillSendFill } from 'react-icons/bs';
 // import { Flex } from 'antd';
 // eslint-disable-next-line require-jsdoc
@@ -17,7 +18,7 @@ export default function Page() {
           type="textarea"
           placeholder="This is a sample textarea"
           size="large"
-          autoSize={{ minRows: 2, maxRows: 6 }}
+          minRows={4}
         />
         <InputField
           type="password"

--- a/src/app/simulations/page.tsx
+++ b/src/app/simulations/page.tsx
@@ -18,7 +18,6 @@ export default function Page() {
           type="textarea"
           placeholder="This is a sample textarea"
           size="large"
-          minRows={4}
         />
         <InputField
           type="password"

--- a/src/components/generic/InputField.tsx
+++ b/src/components/generic/InputField.tsx
@@ -14,66 +14,72 @@ interface InputFieldProps {
   disabled?: boolean;
   showCount?: boolean;
   rows?: number;
+  minRows?: number;
+  maxRows?: number;
   iconRender?: () => React.ReactNode;
-  autoSize?: boolean | object;
 }
 
 const { TextArea } = Input;
 const { Password } = Input;
-// eslint-disable-next-line require-jsdoc
+
 export const InputField = (props: InputFieldProps) => {
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+    }
+    // Call the original onPressEnter if defined and shift key is pressed
+    if (e.key === 'Enter' && e.shiftKey && props.onPressEnter) {
+      props.onPressEnter();
+    }
+  };
+
   if (props.type === 'textarea') {
     return (
-      <>
-        <TextArea
-          rows={props.rows}
-          autoSize={props.autoSize}
-          placeholder={props.placeholder}
-          id={props.id}
-          value={props.value}
-          onChange={props.onChange}
-          onPressEnter={props.onPressEnter}
-          maxLength={props.maxLength}
-          disabled={props.disabled}
-          showCount={props.showCount}
-        />
-      </>
+      <TextArea
+        size={props.size}
+        rows={props.rows}
+        autoSize={{ minRows: props.minRows, maxRows: 6 || props.maxRows }}
+        placeholder={props.placeholder}
+        id={props.id}
+        value={props.value}
+        onChange={props.onChange}
+        onKeyDown={handleKeyPress} // Modified to use onKeyDown
+        maxLength={props.maxLength}
+        disabled={props.disabled}
+        showCount={props.showCount}
+      />
     );
   } else if (props.type === 'password') {
     return (
-      <>
-        <Password
-          size={props.size}
-          placeholder={props.placeholder}
-          suffix={props.suffix}
-          id={props.id}
-          value={props.value}
-          onChange={props.onChange}
-          onPressEnter={props.onPressEnter}
-          maxLength={props.maxLength}
-          disabled={props.disabled}
-          showCount={props.showCount}
-          iconRender={props.iconRender}
-        />
-      </>
+      <Password
+        size={props.size}
+        placeholder={props.placeholder}
+        suffix={props.suffix}
+        id={props.id}
+        value={props.value}
+        onChange={props.onChange}
+        onPressEnter={props.onPressEnter}
+        maxLength={props.maxLength}
+        disabled={props.disabled}
+        showCount={props.showCount}
+        iconRender={props.iconRender}
+      />
     );
   } else {
     return (
-      <>
-        <Input
-          size={props.size}
-          placeholder={props.placeholder}
-          suffix={props.suffix}
-          id={props.id}
-          value={props.value}
-          type={props.type}
-          onChange={props.onChange}
-          onPressEnter={props.onPressEnter}
-          maxLength={props.maxLength}
-          disabled={props.disabled}
-          showCount={props.showCount}
-        />
-      </>
+      <Input
+        size={props.size}
+        placeholder={props.placeholder}
+        suffix={props.suffix}
+        id={props.id}
+        value={props.value}
+        type={props.type}
+        onChange={props.onChange}
+        onPressEnter={props.onPressEnter}
+        maxLength={props.maxLength}
+        disabled={props.disabled}
+        showCount={props.showCount}
+      />
     );
   }
 };

--- a/src/components/generic/InputField.tsx
+++ b/src/components/generic/InputField.tsx
@@ -13,7 +13,6 @@ interface InputFieldProps {
   maxLength?: number;
   disabled?: boolean;
   showCount?: boolean;
-  rows?: number;
   minRows?: number;
   maxRows?: number;
   iconRender?: () => React.ReactNode;
@@ -37,7 +36,6 @@ export const InputField = (props: InputFieldProps) => {
     return (
       <TextArea
         size={props.size}
-        rows={props.rows}
         autoSize={{ minRows: props.minRows, maxRows: 6 || props.maxRows }}
         placeholder={props.placeholder}
         id={props.id}


### PR DESCRIPTION

![Screenshot from 2023-11-24 18-01-05](https://github.com/tum-v2/parloa-ui/assets/43044722/711ada70-2ebf-464c-a195-faeaf314b030)


The following changes have been made:
AutoSize is now the default behavior. You can set the minRows and maxRows props. If the maxRows prop isn't set, it defaults to 6 rows.
If you press Enter in a type:text area, unless you define a function for onPressEnter, nothing happens. You have to press Shift+Enter to go to the next line.
Borders have been fixed, and all types of input have the same borders.
Challenges:
If we plan to use the textarea for the chat page to get user input, you cannot add a button to the input field. It can only be of type:text to add a suffix/button.
Recommendation:
For now, use the type:text input field. In the future, consider creating a custom input field.

