### PR TITLE
Feature/par 149 uiux add simulation page with data table

### DIFF
--- a/src/api/schemas/agent.ts
+++ b/src/api/schemas/agent.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ConversationSchema } from './conversation';
 
 export const AgentSchema = z.object({
   _id: z.string(),
@@ -7,6 +8,7 @@ export const AgentSchema = z.object({
   temperature: z.number(),
   maxTokens: z.number(),
   prompt: z.string(),
+  conversations: ConversationSchema.array(),
   updatedAt: z.string().datetime(),
   createdAt: z.string().datetime()
 });

--- a/src/api/schemas/conversation.ts
+++ b/src/api/schemas/conversation.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
-import { AgentSchema } from './agent';
 
 export const MessageSchema = z.object({
   _id: z.string(),
-  sender: AgentSchema,
+  sender: z.string(),
   text: z.string(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime()

--- a/src/api/schemas/simulation.ts
+++ b/src/api/schemas/simulation.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { ConversationSchema } from './conversation';
-import { AgentSchema } from './agent';
 
 export const SimulationSchema = z.object({
   _id: z.string(),
@@ -9,9 +8,9 @@ export const SimulationSchema = z.object({
   name: z.string(),
   scenario: z.string(),
   domain: z.string(),
-  type: z.string(),
+  type: z.enum(['AUTOMATED', 'MANUAL', 'OPTIMIZATION', 'A/B TESTING']),
   numConversations: z.number(),
-  agents: AgentSchema.array(),
+  agents: z.array(z.string()),
   conversations: ConversationSchema.array(),
   status: z.string(),
   createdAt: z.string().datetime(),

--- a/src/api/simulation.ts
+++ b/src/api/simulation.ts
@@ -17,3 +17,21 @@ export const getSimulation = async (id: string) => {
 
   return zodResponse.data;
 };
+
+/**
+ * /simulation/all Get all simulations
+ */
+export const getAllSimulations = async () => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SIMULATION_API_URL}/simulation/all`
+  );
+
+  const zodResponse = SimulationSchema.array().safeParse(await response.json());
+
+  // Return error to react-query
+  if (!zodResponse.success) {
+    throw new Error(zodResponse.error.message);
+  }
+
+  return zodResponse.data;
+};

--- a/src/app/simulations/SimulationTable.tsx
+++ b/src/app/simulations/SimulationTable.tsx
@@ -1,8 +1,53 @@
+'use client';
+import { Simulation } from '@/api/schemas/simulation';
+import useSimulations from '@/hooks/useSimulations';
+import Table, { ColumnsType } from 'antd/es/table';
+import { useRouter } from 'next/navigation';
+
+const columns: ColumnsType<Simulation> = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name'
+  },
+  {
+    title: 'Scenario',
+    dataIndex: 'scenario',
+    key: 'scenario'
+  },
+  {
+    title: 'Domain',
+    dataIndex: 'domain',
+    key: 'domain'
+  },
+  {
+    title: 'Type',
+    dataIndex: 'type',
+    key: 'type'
+  }
+];
+
 const SimulationTable = () => {
+  const { data, isLoading } = useSimulations();
+  const router = useRouter();
+
+  //Handle row click
+  const handleRowClick = (record: Simulation) => {
+    router.push(`/simulations/details/${record._id}`);
+  };
+
   return (
-    <div>
-      <h1>Simulation Table</h1>
-    </div>
+    <Table
+      columns={columns}
+      dataSource={data}
+      loading={isLoading}
+      rowKey={record => record._id}
+      onRow={record => {
+        return {
+          onClick: () => handleRowClick(record)
+        };
+      }}
+    />
   );
 };
 

--- a/src/app/simulations/SimulationTable.tsx
+++ b/src/app/simulations/SimulationTable.tsx
@@ -1,0 +1,9 @@
+const SimulationTable = () => {
+  return (
+    <div>
+      <h1>Simulation Table</h1>
+    </div>
+  );
+};
+
+export default SimulationTable;

--- a/src/app/simulations/page.tsx
+++ b/src/app/simulations/page.tsx
@@ -1,12 +1,18 @@
-// 'use client';
+'use client';
 // import { InputField } from '@/components/generic/InputField';
 // import { BsFillSendFill } from 'react-icons/bs';
 // import { Flex } from 'antd';
+
+import { Typography } from 'antd';
+import SimulationTable from './SimulationTable';
+
+const { Title } = Typography;
+
 // eslint-disable-next-line require-jsdoc
 export default function Page() {
   return (
     <>
-      <h1>Hello, Simulations Page!</h1>
+      <Title level={2}>Simulations</Title>
       {/* <Flex vertical gap={32}>
         <InputField
           type="text"
@@ -25,6 +31,7 @@ export default function Page() {
           size="large"
         />
       </Flex> */}
+      <SimulationTable />
     </>
   );
 }

--- a/src/hooks/useSimulations.tsx
+++ b/src/hooks/useSimulations.tsx
@@ -1,0 +1,13 @@
+import { Simulation } from '@/api/schemas/simulation';
+import { getAllSimulations } from '@/api/simulation';
+import { useQuery } from '@tanstack/react-query';
+
+const useSimulations = () => {
+  const query = useQuery<Simulation[], Error>({
+    queryKey: ['simulations'],
+    queryFn: getAllSimulations
+  });
+  return query;
+};
+
+export default useSimulations;


### PR DESCRIPTION
- Added basic implementation of the simulation table
- Added query to fetch all simulations
<img width="1508" alt="image" src="https://github.com/tum-v2/parloa-ui/assets/46896242/6c660c34-3486-450c-b057-d75a6a7190a6">
