### PR TITLE
Use percentage sizings instead of px in modal

### DIFF
--- a/src/components/simulation-modal/ModelCard.tsx
+++ b/src/components/simulation-modal/ModelCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Card, Select, Button, Typography } from 'antd';
+import { Card, Select, Button, Typography, Flex } from 'antd';
 import { EditOutlined } from '@ant-design/icons';
 import theme from '@/theme/theme';
 
 const { Option } = Select;
-const { Text } = Typography;
+const { Title } = Typography;
 
 interface ModelCardProps {
   models: string[];
@@ -17,28 +17,16 @@ interface ModelCardProps {
 }
 
 const cardStyle: React.CSSProperties = {
-  width: 300,
-  height: 400,
   border: '1px solid',
-  padding: theme.padding.l
-};
-
-const wrapperStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
   height: '100%',
-  justifyContent: 'space-between'
+  width: '100%'
 };
-
-const textStyle: React.CSSProperties = { fontSize: theme.fontSize.xl };
 
 const iconStyle: React.CSSProperties = { margin: theme.margin.l };
 
 const selectStyle: React.CSSProperties = {
   width: '100%',
-  marginBottom: theme.margin.m,
-  height: 40
+  marginBottom: theme.margin.m
 };
 
 const labelStyle: React.CSSProperties = {
@@ -47,16 +35,9 @@ const labelStyle: React.CSSProperties = {
   fontSize: theme.fontSize.m
 };
 
-const scenarioWrapperStyle: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  width: '100%'
-};
-
 const scenarioSelectStyle: React.CSSProperties = {
   flex: 1,
-  marginRight: theme.margin.m,
-  height: 40
+  marginRight: theme.margin.m
 };
 
 const ModelCard = ({
@@ -69,9 +50,9 @@ const ModelCard = ({
   title
 }: ModelCardProps) => {
   return (
-    <Card style={cardStyle}>
-      <div style={wrapperStyle}>
-        <Text style={textStyle}>{title}</Text>
+    <Card style={cardStyle} bodyStyle={{ height: '100%' }}>
+      <Flex justify="center" align="center" className="h-full" vertical>
+        <Title level={4}>{title}</Title>
         <div style={iconStyle}>{icon}</div>
         <Select
           defaultValue={models[0]}
@@ -87,7 +68,7 @@ const ModelCard = ({
         <label htmlFor="scenario" style={labelStyle}>
           Instruction Template
         </label>
-        <div style={scenarioWrapperStyle}>
+        <Flex align="center" className="w-full">
           <Select
             id="scenario"
             defaultValue={scenarios[0]}
@@ -105,8 +86,8 @@ const ModelCard = ({
             icon={<EditOutlined />}
             onClick={onButtonClick}
           />
-        </div>
-      </div>
+        </Flex>
+      </Flex>
     </Card>
   );
 };

--- a/src/components/simulation-modal/ModelCard.tsx
+++ b/src/components/simulation-modal/ModelCard.tsx
@@ -19,7 +19,8 @@ interface ModelCardProps {
 const cardStyle: React.CSSProperties = {
   border: '1px solid',
   height: '100%',
-  width: '100%'
+  width: '100%',
+  minWidth: '200px'
 };
 
 const iconStyle: React.CSSProperties = { margin: theme.margin.l };

--- a/src/components/simulation-modal/SimulationCard.tsx
+++ b/src/components/simulation-modal/SimulationCard.tsx
@@ -16,7 +16,8 @@ const cardStyleBase: React.CSSProperties = {
   border: '1px solid',
   cursor: 'pointer',
   height: '100%',
-  width: '100%'
+  width: '100%',
+  minWidth: '200px'
 };
 
 const iconAndTextStyle: React.CSSProperties = {

--- a/src/components/simulation-modal/SimulationCard.tsx
+++ b/src/components/simulation-modal/SimulationCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Card, Typography } from 'antd';
+import { Card, Flex, Typography } from 'antd';
 import theme from '@/theme/theme';
 
 const { Text } = Typography;
@@ -13,33 +13,20 @@ interface SimulationCardProps {
 }
 
 const cardStyleBase: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: 300,
-  height: 400,
   border: '1px solid',
-  cursor: 'pointer'
+  cursor: 'pointer',
+  height: '100%',
+  width: '100%'
 };
 
 const iconAndTextStyle: React.CSSProperties = {
-  fontWeight: 'normal',
-  marginBottom: '4px',
-  fontSize: '22px',
+  marginBottom: theme.margin.xs,
+  fontSize: theme.fontSize.xl,
   textAlign: 'center'
 };
 
-const wrapperStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  justifyContent: 'center',
-  height: '100%'
-};
-
 const iconStyle: React.CSSProperties = {
-  marginBottom: '24px'
+  marginBottom: theme.margin.l
 };
 
 const getModeColors = (mode: 'manual' | 'automated') =>
@@ -100,13 +87,14 @@ const SimulationCard = ({
       onMouseEnter={() => selectable && setHover(true)}
       onMouseLeave={() => selectable && setHover(false)}
       onClick={handleCardClick}
+      bodyStyle={{ height: '100%' }}
     >
-      <div style={wrapperStyle}>
+      <Flex justify="center" align="center" className="h-full" vertical>
         <span style={{ ...iconStyle, color: textStyle.color }}>{icon}</span>
         <Text style={textStyle}>{title}</Text>
         <Text style={textStyle}>Simulation</Text>
         {children}
-      </div>
+      </Flex>
     </Card>
   );
 };

--- a/src/components/simulation-modal/StepContent.tsx
+++ b/src/components/simulation-modal/StepContent.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select, Slider, Segmented } from 'antd';
+import { Select, Slider, Segmented, Flex } from 'antd';
 import SimulationCard from './SimulationCard';
 import ModelCard from './ModelCard';
 import { InputField } from '../generic/InputField';
@@ -23,16 +23,6 @@ const StepContent: React.FC<StepContentProps> = ({
   const [temperature, setTemperature] = useState<number>(0.5);
   const [maxTokens, setMaxTokens] = useState<number>(2048);
 
-  const wrapperStyle: React.CSSProperties = { padding: theme.padding.l };
-  const cardStyle: React.CSSProperties = {
-    width: '300px',
-    padding: theme.padding.l
-  };
-  const inputFieldStyle: React.CSSProperties = { marginBottom: theme.margin.l };
-  const sliderContainerStyle: React.CSSProperties = {
-    marginTop: theme.margin.l
-  };
-
   const handleModelChange = () => {
     console.log(`Selected Model`);
   };
@@ -49,8 +39,8 @@ const StepContent: React.FC<StepContentProps> = ({
     switch (stepNumber) {
       case 1:
         return (
-          <div style={{ display: 'flex' }}>
-            <div style={wrapperStyle}>
+          <Flex className="w-full h-full" align="center" justify="center">
+            <div className="w-1/5 h-3/4 px-6">
               <SimulationCard
                 selectable={true}
                 title="Manual"
@@ -58,7 +48,7 @@ const StepContent: React.FC<StepContentProps> = ({
                 icon={<AiFillCode size={100} />}
               />
             </div>
-            <div style={wrapperStyle}>
+            <div className="w-1/5 h-3/4 px-6">
               <SimulationCard
                 selectable={true}
                 title="Automated"
@@ -66,20 +56,13 @@ const StepContent: React.FC<StepContentProps> = ({
                 icon={<IoReload size={100} />}
               />
             </div>
-          </div>
+          </Flex>
         );
 
       case 2:
         return (
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              height: '100%'
-            }}
-          >
-            <div style={cardStyle}>
+          <Flex justify="center" align="flex-start" className="h-3/4 w-full">
+            <div className="w-1/5 h-full px-6">
               <SimulationCard
                 selectable={false}
                 title="Automated"
@@ -87,45 +70,43 @@ const StepContent: React.FC<StepContentProps> = ({
                 icon={<AiFillCode size={100} />}
               />
             </div>
-            <div style={cardStyle}>
-              <div style={inputFieldStyle}>
+            <Flex vertical className="w-1/3 px-6" gap={'middle'}>
+              <div>
                 <label
                   htmlFor="simulation-name"
-                  style={{ display: 'block', marginBottom: theme.padding.s }}
+                  style={{ display: 'block', marginBottom: theme.margin.s }}
                 >
                   Simulation Name
                 </label>
                 <InputField
                   id="simulation-name"
                   type="text"
-                  size="large"
                   placeholder="Simulation Name"
                 />
               </div>
               <div>
                 <label
                   htmlFor="simulation-description"
-                  style={{ display: 'block', marginBottom: theme.padding.s }}
+                  style={{ display: 'block', marginBottom: theme.margin.s }}
                 >
                   Description
                 </label>
                 <InputField
                   id="simulation-description"
                   type="textarea"
-                  size="large"
                   placeholder="Description"
                   minRows={10}
                   maxRows={10}
                 />
               </div>
-            </div>
-          </div>
+            </Flex>
+          </Flex>
         );
 
       case 3:
         return (
-          <div style={{ display: 'flex' }}>
-            <div style={wrapperStyle}>
+          <Flex justify="center" align="center" className="h-3/4 w-full">
+            <div className="w-1/5 h-full px-6">
               <SimulationCard
                 selectable={false}
                 title="Automated"
@@ -133,7 +114,7 @@ const StepContent: React.FC<StepContentProps> = ({
                 icon={<AiFillCode size={100} />}
               />
             </div>
-            <div style={wrapperStyle}>
+            <div className="w-1/5 h-full px-6">
               <ModelCard
                 models={models}
                 scenarios={scenarios}
@@ -144,7 +125,7 @@ const StepContent: React.FC<StepContentProps> = ({
                 title="Agent LLM"
               />
             </div>
-            <div style={wrapperStyle}>
+            <div className="w-1/5 h-full px-6">
               <ModelCard
                 models={models}
                 scenarios={scenarios}
@@ -155,58 +136,63 @@ const StepContent: React.FC<StepContentProps> = ({
                 title="User LLM"
               />
             </div>
-          </div>
+          </Flex>
         );
 
       case 9:
         return (
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              height: '100%',
-              width: '80%'
-            }}
-          >
-            <div style={{ width: '40%', padding: theme.padding.l }}>
-              <div style={inputFieldStyle}>
+          <Flex justify="space-between" align="flex-start" className="w-full">
+            <Flex
+              vertical
+              gap="middle"
+              className="w-full"
+              style={{ padding: theme.padding.l }}
+            >
+              <div>
                 <label
                   htmlFor="template-name"
-                  style={{ display: 'block', marginBottom: theme.padding.s }}
+                  style={{ display: 'block', marginBottom: theme.margin.s }}
                 >
                   Template Name
                 </label>
-                <InputField id="template-name" type="text" size="large" />
+                <InputField id="template-name" type="text" />
               </div>
-              <div style={inputFieldStyle}>
+              <div>
                 <label
                   htmlFor="instructions"
-                  style={{ display: 'block', marginBottom: theme.padding.s }}
+                  style={{ display: 'block', marginBottom: theme.margin.s }}
                 >
                   Instructions
                 </label>
-                <InputField
-                  id="instructions"
-                  type="textarea"
-                  size="large"
-                  minRows={6}
+                <InputField id="instructions" type="textarea" minRows={6} />
+              </div>
+            </Flex>
+            <Flex
+              vertical
+              gap="middle"
+              className="w-full"
+              style={{ padding: theme.padding.l }}
+            >
+              <div>
+                <label
+                  htmlFor="instructions"
+                  style={{ display: 'block', marginBottom: theme.margin.s }}
+                >
+                  Scenario
+                </label>
+                <Select
+                  defaultValue="Sequence"
+                  onChange={handleScenarioTypeChange}
+                  options={[
+                    { value: 'Sequence', label: 'Sequence' },
+                    { value: 'Slot Filling', label: 'Slot Filling' },
+                    { value: 'Call Forward', label: 'Call Forward' }
+                  ]}
                 />
               </div>
-            </div>
-            <div style={{ width: '40%', padding: theme.padding.l }}>
-              <Select
-                defaultValue="Sequence"
-                style={{ width: 120 }}
-                onChange={handleScenarioTypeChange}
-                options={[
-                  { value: 'Sequence', label: 'Sequence' },
-                  { value: 'Slot Filling', label: 'Slot Filling' },
-                  { value: 'Call Forward', label: 'Call Forward' }
-                ]}
-              />
-              <div style={sliderContainerStyle}>
-                <label>Temperature (0 - 1):</label>
+
+              <div>
+                <label>Temperature (0 - 1)</label>
                 <Slider
                   min={0}
                   max={1}
@@ -215,8 +201,8 @@ const StepContent: React.FC<StepContentProps> = ({
                   onChange={value => setTemperature(value as number)}
                 />
               </div>
-              <div style={sliderContainerStyle}>
-                <label>Max Tokens (1024 - 4096):</label>
+              <div>
+                <label>Max Tokens (1024 - 4096)</label>
                 <Slider
                   min={1024}
                   max={4096}
@@ -225,13 +211,16 @@ const StepContent: React.FC<StepContentProps> = ({
                   onChange={value => setMaxTokens(value as number)}
                 />
               </div>
-              <div style={sliderContainerStyle}>
-                <label>Overwrite Template:</label>
-                <br />
+              <div>
+                <label
+                  style={{ display: 'block', marginBottom: theme.margin.s }}
+                >
+                  Overwrite Template
+                </label>
                 <Segmented options={['Yes', 'No']} />
               </div>
-            </div>
-          </div>
+            </Flex>
+          </Flex>
         );
 
       default:


### PR DESCRIPTION
- Remove card sizing in pixels
- Cleanup unnecessary styles
- Improve styling consistency 

![Recording 2023-12-10 at 14 38 26](https://github.com/tum-v2/parloa-ui/assets/46896242/1eda8454-bb9b-49e9-a78b-1bbb7cb71dad)
