### PR TITLE
Fix onClick event in NavBarTab component

### DIFF
--- a/src/components/nav-bar/components/NavBarTab.tsx
+++ b/src/components/nav-bar/components/NavBarTab.tsx
@@ -64,7 +64,10 @@ const NavBarTab = ({ selectedTab, setSelectedTab }: NavBarTabProps) => {
         options={navBarTabOptions.map((option, index) => {
           return {
             label: (
-              <div style={navBarTabElementStyle}>
+              <div
+                style={navBarTabElementStyle}
+                onClick={() => router.push(option.route)}
+              >
                 <div style={navBarTabElementIconStyle}>{option.icon}</div>
                 <div>{option.name}</div>
               </div>
@@ -74,9 +77,7 @@ const NavBarTab = ({ selectedTab, setSelectedTab }: NavBarTabProps) => {
         })}
         value={selectedTab}
         onChange={value => {
-          const navBarTab = navBarTabOptions[value as number];
           setSelectedTab(value as number);
-          router.push(navBarTab.route);
         }}
       />
     </ConfigProvider>


### PR DESCRIPTION
- Fixes an issue where the route would not get pushed when clicking on the already selected navbar tab. For example it would not be possible to return to the simulation table from the details page when clicking on Simulations in the navbar since it was already selected.