### PR TITLE
Add child simulation pill to DetailsHeader

### DIFF
--- a/src/app/simulations/details/[id]/DetailsHeader.tsx
+++ b/src/app/simulations/details/[id]/DetailsHeader.tsx
@@ -7,6 +7,8 @@ import { formatLongDateTimeString } from '@/lib/utils/dateTime';
 import { Simulation } from '@/api/schemas/simulation';
 import { firstLetterToUpperCase, underscoresToSpaces } from '@/lib/utils/text';
 import { useRouter } from 'next/navigation';
+import theme from '@/theme/theme';
+import { SlidersOutlined } from '@ant-design/icons';
 
 interface DetailsHeaderProps {
   simulation: Simulation;
@@ -37,6 +39,11 @@ const DetailsHeader = ({ simulation }: DetailsHeaderProps) => {
         <Pill color={typeStyle.color} icon={<typeStyle.icon />}>
           {underscoresToSpaces(firstLetterToUpperCase(type))}
         </Pill>
+        {simulation.type === 'OPTIMIZATION' && !simulation.optimization && (
+          <Pill color={theme.color.cyan} icon={<SlidersOutlined />}>
+            {'Child simulation'}
+          </Pill>
+        )}
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
Added an indicator pill to show that a simulation is part of an optimization instance.
<img width="1505" alt="image" src="https://github.com/tum-v2/parloa-ui/assets/46896242/3885c594-0c04-4488-9449-a0a144f8b5b6">
