### PR TITLE
Feature/sort delete simulation table

### DIFF
--- a/src/api/schemas/simulation.ts
+++ b/src/api/schemas/simulation.ts
@@ -94,8 +94,13 @@ export const CreateSimulationResponseSchema = z.object({
   updatedAt: z.string().datetime()
 });
 
+export const DeleteSimulationSchema = z.object({
+  _id: z.string()
+});
+
 export type Simulation = z.infer<typeof SimulationSchema>;
 export type CreateSimulation = z.infer<typeof CreateSimulationSchema>;
 export type CreateSimulationResponse = z.infer<
   typeof CreateSimulationResponseSchema
 >;
+export type DeleteSimulation = z.infer<typeof DeleteSimulationSchema>;

--- a/src/api/simulation.ts
+++ b/src/api/simulation.ts
@@ -2,7 +2,8 @@ import { CreateOptimizationResponseSchema } from './schemas/optimization';
 import {
   SimulationSchema,
   CreateSimulation,
-  CreateSimulationResponseSchema
+  CreateSimulationResponseSchema,
+  DeleteSimulation
 } from './schemas/simulation';
 
 /**
@@ -102,4 +103,24 @@ export const createOptimizedSimulation = async (
   }
 
   return zodResponse.data;
+};
+
+export const deleteSimulation = async (
+  deleteSimulationData: DeleteSimulation
+) => {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SIMULATION_API_URL}/simulation/${deleteSimulationData._id}`,
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to create simulation'); // Handle non-2xx HTTP responses
+  }
+  // Becuase the response is empty, we can't use zod to parse it
+  return response;
 };

--- a/src/app/simulations/SimulationTable.tsx
+++ b/src/app/simulations/SimulationTable.tsx
@@ -15,12 +15,16 @@ const columns: ColumnsType<Simulation> = [
   {
     title: 'Name',
     dataIndex: 'name',
-    key: 'name'
+    key: 'name',
+    sortDirections: ['ascend', 'descend'],
+    sorter: (a, b) => a.name.localeCompare(b.name)
   },
   {
     title: 'Type',
     dataIndex: 'type',
     key: 'type',
+    sortDirections: ['ascend', 'descend'],
+    sorter: (a, b) => a.type.localeCompare(b.type),
     render: (type: SimulationType) => {
       const typeStyle = getSimulationTypeStyle(type);
       return (
@@ -34,6 +38,8 @@ const columns: ColumnsType<Simulation> = [
     title: 'Status',
     dataIndex: 'status',
     key: 'status',
+    sortDirections: ['ascend', 'descend'],
+    sorter: (a, b) => a.status.localeCompare(b.status),
     render: (status: string) => {
       return (
         <Badge
@@ -47,6 +53,11 @@ const columns: ColumnsType<Simulation> = [
     title: 'Created At',
     dataIndex: 'createdAt',
     key: 'createdAt',
+    defaultSortOrder: 'descend',
+    sortDirections: ['ascend', 'descend'],
+    sorter: (a, b) => {
+      return Date.parse(a.createdAt) - Date.parse(b.createdAt);
+    },
     render: (createdAt: string) => {
       return <span>{new Date(createdAt).toLocaleString()}</span>; // TODO: Change to appropiate format (ask client)
     }
@@ -55,6 +66,10 @@ const columns: ColumnsType<Simulation> = [
     title: 'Updated At',
     dataIndex: 'updatedAt',
     key: 'updatedAt',
+    sortDirections: ['ascend', 'descend'],
+    sorter: (a, b) => {
+      return Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
+    },
     render: (updatedAt: string) => {
       return <span>{new Date(updatedAt).toLocaleString()}</span>;
     }

--- a/src/app/simulations/SimulationTable.tsx
+++ b/src/app/simulations/SimulationTable.tsx
@@ -106,7 +106,12 @@ const SimulationTable = () => {
 
   //Handle row click
   const handleRowClick = (record: Simulation) => {
-    router.push(`/simulations/details/${record._id}`);
+    //Route to simulation chat page if simulation is of type CHAT
+    if (record.type === 'CHAT') {
+      router.push(`/simulations/details/${record._id}/chat`);
+    } else {
+      router.push(`/simulations/details/${record._id}`);
+    }
   };
 
   return (
@@ -115,11 +120,6 @@ const SimulationTable = () => {
       dataSource={data}
       loading={isLoading}
       rowKey={record => record._id}
-      // onRow={record => {
-      //   return {
-      //     // onClick: () => handleRowClick(record)
-      //   };
-      // }}
       className="cursor-pointer"
     />
   );

--- a/src/app/simulations/SimulationTable.tsx
+++ b/src/app/simulations/SimulationTable.tsx
@@ -7,78 +7,102 @@ import {
   getSimulationTypeStyle
 } from '@/lib/utils/simulations/simulationStyles';
 import { firstLetterToUpperCase } from '@/lib/utils/text';
-import { Badge } from 'antd';
+import { Badge, Button, Popconfirm, Space } from 'antd';
 import Table, { ColumnsType } from 'antd/es/table';
 import { useRouter } from 'next/navigation';
-
-const columns: ColumnsType<Simulation> = [
-  {
-    title: 'Name',
-    dataIndex: 'name',
-    key: 'name',
-    sortDirections: ['ascend', 'descend'],
-    sorter: (a, b) => a.name.localeCompare(b.name)
-  },
-  {
-    title: 'Type',
-    dataIndex: 'type',
-    key: 'type',
-    sortDirections: ['ascend', 'descend'],
-    sorter: (a, b) => a.type.localeCompare(b.type),
-    render: (type: SimulationType) => {
-      const typeStyle = getSimulationTypeStyle(type);
-      return (
-        <Pill color={typeStyle.color} icon={<typeStyle.icon />}>
-          {firstLetterToUpperCase(type)}
-        </Pill>
-      );
-    }
-  },
-  {
-    title: 'Status',
-    dataIndex: 'status',
-    key: 'status',
-    sortDirections: ['ascend', 'descend'],
-    sorter: (a, b) => a.status.localeCompare(b.status),
-    render: (status: string) => {
-      return (
-        <Badge
-          status={getSimulationStatusBadgeStatus(status)}
-          text={firstLetterToUpperCase(status)}
-        />
-      );
-    }
-  },
-  {
-    title: 'Created At',
-    dataIndex: 'createdAt',
-    key: 'createdAt',
-    defaultSortOrder: 'descend',
-    sortDirections: ['ascend', 'descend'],
-    sorter: (a, b) => {
-      return Date.parse(a.createdAt) - Date.parse(b.createdAt);
-    },
-    render: (createdAt: string) => {
-      return <span>{new Date(createdAt).toLocaleString()}</span>; // TODO: Change to appropiate format (ask client)
-    }
-  },
-  {
-    title: 'Updated At',
-    dataIndex: 'updatedAt',
-    key: 'updatedAt',
-    sortDirections: ['ascend', 'descend'],
-    sorter: (a, b) => {
-      return Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
-    },
-    render: (updatedAt: string) => {
-      return <span>{new Date(updatedAt).toLocaleString()}</span>;
-    }
-  }
-];
+import { DeleteOutlined } from '@ant-design/icons';
+import useDeleteSimulation from '@/hooks/useDeleteSimulation';
 
 const SimulationTable = () => {
   const { data, isLoading } = useSimulations();
   const router = useRouter();
+  const deleteSimulation = useDeleteSimulation();
+
+  const columns: ColumnsType<Simulation> = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      sortDirections: ['ascend', 'descend'],
+      sorter: (a, b) => a.name.localeCompare(b.name),
+      render: (_, record) => (
+        <a onClick={() => handleRowClick(record)}>{record.name}</a>
+      )
+    },
+    {
+      title: 'Type',
+      dataIndex: 'type',
+      key: 'type',
+      sortDirections: ['ascend', 'descend'],
+      sorter: (a, b) => a.type.localeCompare(b.type),
+      render: (type: SimulationType) => {
+        const typeStyle = getSimulationTypeStyle(type);
+        return (
+          <Pill color={typeStyle.color} icon={<typeStyle.icon />}>
+            {firstLetterToUpperCase(type)}
+          </Pill>
+        );
+      }
+    },
+    {
+      title: 'Status',
+      dataIndex: 'status',
+      key: 'status',
+      sortDirections: ['ascend', 'descend'],
+      sorter: (a, b) => a.status.localeCompare(b.status),
+      render: (status: string) => {
+        return (
+          <Badge
+            status={getSimulationStatusBadgeStatus(status)}
+            text={firstLetterToUpperCase(status)}
+          />
+        );
+      }
+    },
+    {
+      title: 'Created At',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      defaultSortOrder: 'descend',
+      sortDirections: ['ascend', 'descend'],
+      sorter: (a, b) => {
+        return Date.parse(a.createdAt) - Date.parse(b.createdAt);
+      },
+      render: (createdAt: string) => {
+        return <span>{new Date(createdAt).toLocaleString()}</span>; // TODO: Change to appropiate format (ask client)
+      }
+    },
+    {
+      title: 'Updated At',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      sortDirections: ['ascend', 'descend'],
+      sorter: (a, b) => {
+        return Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
+      },
+      render: (updatedAt: string) => {
+        return <span>{new Date(updatedAt).toLocaleString()}</span>;
+      }
+    },
+    {
+      title: '',
+      key: 'action',
+      render: (_, record) => (
+        <Popconfirm
+          title="Confirm to delete?"
+          onConfirm={() => {
+            deleteSimulation.mutate({ _id: record._id });
+          }}
+        >
+          <Space size="middle">
+            <Button type="link" danger>
+              <DeleteOutlined />
+            </Button>
+          </Space>
+        </Popconfirm>
+      )
+    }
+  ];
 
   //Handle row click
   const handleRowClick = (record: Simulation) => {
@@ -91,11 +115,11 @@ const SimulationTable = () => {
       dataSource={data}
       loading={isLoading}
       rowKey={record => record._id}
-      onRow={record => {
-        return {
-          onClick: () => handleRowClick(record)
-        };
-      }}
+      // onRow={record => {
+      //   return {
+      //     // onClick: () => handleRowClick(record)
+      //   };
+      // }}
       className="cursor-pointer"
     />
   );

--- a/src/app/simulations/page.tsx
+++ b/src/app/simulations/page.tsx
@@ -7,10 +7,13 @@ import { InputField } from '@/components/generic/InputField';
 import SimulationModal from '@/components/simulation-modal/SimulationModal';
 import { SearchOutlined } from '@ant-design/icons';
 import { Flex, DatePicker, Space } from 'antd';
+import { useState } from 'react';
 
 const { RangePicker } = DatePicker;
 
 const Page = () => {
+  // TODO: Handle Search
+  const [search, setSearch] = useState<string>('');
   return (
     <Content>
       <Header title="Simulations" />
@@ -25,6 +28,8 @@ const Page = () => {
             placeholder="Search"
             type="text"
             prefix={<SearchOutlined />}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
           />
           <RangePicker
             showTime={{ format: 'HH:mm' }}

--- a/src/hooks/useDeleteSimulation.tsx
+++ b/src/hooks/useDeleteSimulation.tsx
@@ -1,0 +1,22 @@
+import { DeleteSimulation } from '@/api/schemas/simulation';
+import { deleteSimulation } from '@/api/simulation';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useDeleteSimulation = () => {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationKey: ['deleteSimulation'],
+    mutationFn: (simulation: DeleteSimulation) => deleteSimulation(simulation),
+    onSuccess: () => {
+      // Update all simulations query
+      queryClient.invalidateQueries({ queryKey: ['simulations'] });
+    },
+    onError: error => {
+      console.log(error);
+    }
+  });
+  return mutation;
+};
+
+export default useDeleteSimulation;


### PR DESCRIPTION
- The table is sorted default now by `createdAt` descending so the latest one would be up first
- Table can also be sorted with every column
- I had to change from click on anywhere on the row to simulation detail, to only the name, otherwise delete button won't be clickable as it would always go to simulation detail

<img width="1050" alt="Screenshot 2023-12-16 at 23 55 43" src="https://github.com/tum-v2/parloa-ui/assets/29707419/32b9dbd9-7c94-4aa3-a2b3-4e6ff4555a5d">
