### PR TITLE
HOTFIX - Move public and static folders to /standalone on build

### DIFF
--- a/.github/workflows/azure-static-web-apps-victorious-field-029f0a803.yml
+++ b/.github/workflows/azure-static-web-apps-victorious-field-029f0a803.yml
@@ -30,7 +30,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional
-          output_location: '' # Built app content directory - optional
+          output_location: '.next/standalone' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev -p 3001",
-    "build": "next build",
+    "build": "next build && cp -R public .next/standalone/public && cp -R .next/static .next/standalone/.next/static",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",


### PR DESCRIPTION
- Fixes the issue of the Parloa logo in the top left is not loading in any view. 
- Added commands on build to move the public and static folders under the output folder /standalone.